### PR TITLE
Fix failing tests due to typo in error message

### DIFF
--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -228,7 +228,7 @@ class DjangoPluginTestCase(StdStreamCapturingMixin, TempDirMixin, TestCase):
         stderr = self.stderr()
         self.assertIn(
             "Coverage.py warning: "
-            "Disabling plugin 'django_coverage_plugin.DjangoTemplatePlugin' "
+            "Disabling plug-in 'django_coverage_plugin.DjangoTemplatePlugin' "
             "due to an exception:",
             stderr
         )


### PR DESCRIPTION
Running Travis tests locally for full-verification of PRs.